### PR TITLE
feat(checkout): garantir parcelamento em 3x via Checkout Session API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,14 @@ VITE_DEFAULT_IMAGE_URL=https://dheiver-ai-solutions.com/og-image.jpg
 VITE_TWITTER_CARD_IMAGE=https://dheiver-ai-solutions.com/twitter-card.jpg
 
 # Stripe (mentoria)
+# STRIPE_SECRET_KEY é obrigatório pro /api/create-checkout criar Checkout Sessions
+# com parcelamento em até 3x habilitado (payment_method_options.card.installments).
+# Pré-requisito na conta Stripe: Settings → Payments → Installments ativado (BR).
 STRIPE_SECRET_KEY=sk_live_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+# Publishable key (pública — pode ficar em VITE_*). Só é necessária se usar
+# Stripe Elements; o fluxo padrão via create-checkout não precisa dela no cliente.
+VITE_STRIPE_PUBLISHABLE_KEY=pk_live_xxx
 
 # Resend (email de boas-vindas após pagamento)
 RESEND_API_KEY=re_xxx

--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -1,0 +1,90 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import Stripe from 'stripe';
+
+const stripeSecret = process.env.STRIPE_SECRET_KEY;
+const siteUrl = process.env.VITE_SITE_URL || 'https://dheiver.com.br';
+
+// Parcelamento garantido por c\u00f3digo: habilita installments na Checkout Session.
+// O cliente v\u00ea op\u00e7\u00f5es a partir de 2x; o plano "3x" aparece junto — ancorado pela UI.
+// Pr\u00e9-requisito na conta Stripe (BR): Settings \u2192 Payments \u2192 Installments ativado.
+const TOTAL_PRICE_CENTS = 209100; // R$ 2.091,00
+const INSTALLMENTS = 3;
+const MONTHLY_PRICE = 697;
+
+const readJsonBody = async (req: VercelRequest): Promise<Record<string, unknown>> => {
+  if (req.body && typeof req.body === 'object' && !Buffer.isBuffer(req.body)) {
+    return req.body as Record<string, unknown>;
+  }
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!stripeSecret) {
+    console.error('[stripe] STRIPE_SECRET_KEY missing');
+    return res.status(500).json({ error: 'Stripe n\u00e3o configurado' });
+  }
+
+  const body = await readJsonBody(req);
+  const rawEmail = typeof body.email === 'string' ? body.email.trim().toLowerCase() : undefined;
+  const email = rawEmail && /.+@.+\..+/.test(rawEmail) ? rawEmail : undefined;
+
+  const stripe = new Stripe(stripeSecret);
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      payment_method_options: {
+        card: {
+          installments: { enabled: true },
+        },
+      },
+      locale: 'pt-BR',
+      customer_email: email,
+      line_items: [
+        {
+          price_data: {
+            currency: 'brl',
+            unit_amount: TOTAL_PRICE_CENTS,
+            product_data: {
+              name: 'Mentoria Engenharia de IA J\u00fanior \u2014 3 meses',
+              description: `Acompanhamento 1:1 com Dr. Dheiver. Parcele em at\u00e9 ${INSTALLMENTS}x de R$ ${MONTHLY_PRICE} sem juros no cart\u00e3o. Inclui 12 sess\u00f5es, 5+ projetos, revis\u00e3o de curr\u00edculo e prepara\u00e7\u00e3o para entrevistas.`,
+            },
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: `${siteUrl}/#/obrigado?method=cartao&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${siteUrl}/#/mentoria`,
+      allow_promotion_codes: true,
+      billing_address_collection: 'required',
+      metadata: {
+        product: 'mentoring_3_months',
+        installments_offered: String(INSTALLMENTS),
+        source: 'create-checkout-api',
+      },
+    });
+
+    if (!session.url) {
+      return res.status(500).json({ error: 'Stripe n\u00e3o retornou URL de checkout' });
+    }
+
+    return res.status(200).json({ url: session.url, id: session.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Falha ao criar checkout';
+    console.error('[stripe] create-checkout failed', { error: message });
+    return res.status(500).json({ error: message });
+  }
+}

--- a/src/components/mentoring/MentoringPricing.tsx
+++ b/src/components/mentoring/MentoringPricing.tsx
@@ -8,11 +8,11 @@ import {
   MENTORING_PIX_PRICE,
   MENTORING_PIX_SAVINGS,
   MENTORING_SEATS_LEFT,
-  MENTORING_STRIPE_CARD_LINK,
   MENTORING_STRIPE_PIX_LINK,
   MENTORING_TOTAL_PRICE,
   buildMentoringPixWhatsAppLink,
   buildMentoringWhatsAppLink,
+  startMentoringCheckout,
 } from './mentoringConfig';
 
 const MentoringPricing = () => {
@@ -75,11 +75,14 @@ const MentoringPricing = () => {
 
           {/* Payment options — 2 clear choices, clickable */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
-            <a
-              href={MENTORING_STRIPE_CARD_LINK}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => { if (typeof window !== 'undefined' && window.fbq) { window.fbq('track', 'InitiateCheckout', { content_name: 'pricing_card_stripe', value: MENTORING_TOTAL_PRICE, currency: 'BRL' }); } }}
+            <button
+              type="button"
+              onClick={() => {
+                if (typeof window !== 'undefined' && window.fbq) {
+                  window.fbq('track', 'InitiateCheckout', { content_name: 'pricing_card_stripe', value: MENTORING_TOTAL_PRICE, currency: 'BRL' });
+                }
+                void startMentoringCheckout();
+              }}
               className="relative bg-[#0D1117] border-2 border-emerald-500/30 rounded-xl p-4 text-left transition-all hover:border-emerald-400/60 hover:bg-[#0F1620] hover:-translate-y-0.5"
             >
               <span className="absolute -top-2.5 left-3 text-[9px] font-bold tracking-wider bg-emerald-500 text-black px-2 py-0.5 rounded">SEM JUROS</span>
@@ -87,7 +90,7 @@ const MentoringPricing = () => {
               <p className="text-xl font-bold text-white leading-tight">{MENTORING_INSTALLMENTS}x de R$ {MENTORING_MONTHLY_PRICE}</p>
               <p className="text-[11px] text-slate-400 mt-1">Total: R$ {MENTORING_TOTAL_PRICE}</p>
               <p className="text-[10px] text-emerald-400 mt-2 font-semibold">Pagar agora →</p>
-            </a>
+            </button>
             <a
               href={MENTORING_STRIPE_PIX_LINK || buildMentoringPixWhatsAppLink()}
               target="_blank"
@@ -115,17 +118,20 @@ const MentoringPricing = () => {
             ))}
           </div>
 
-          <motion.a
-            href={MENTORING_STRIPE_CARD_LINK}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => { if (typeof window !== 'undefined' && window.fbq) { window.fbq('track', 'InitiateCheckout', { content_name: 'pricing_main_cta_stripe', value: MENTORING_TOTAL_PRICE, currency: 'BRL' }); } }}
+          <motion.button
+            type="button"
+            onClick={() => {
+              if (typeof window !== 'undefined' && window.fbq) {
+                window.fbq('track', 'InitiateCheckout', { content_name: 'pricing_main_cta_stripe', value: MENTORING_TOTAL_PRICE, currency: 'BRL' });
+              }
+              void startMentoringCheckout();
+            }}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             className="block w-full bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-400 hover:to-amber-500 text-black font-bold text-sm py-4 rounded-lg transition-all duration-300 shadow-lg shadow-amber-500/25"
           >
             PAGAR AGORA COM SEGURANÇA →
-          </motion.a>
+          </motion.button>
           <p className="text-[11px] text-slate-500 mt-3 flex items-center justify-center gap-1.5">
             <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
             Pagamento processado pelo Stripe · Dados criptografados

--- a/src/components/mentoring/StickyBuyCta.tsx
+++ b/src/components/mentoring/StickyBuyCta.tsx
@@ -3,8 +3,8 @@ import { ShoppingCart } from 'lucide-react';
 import {
   MENTORING_INSTALLMENTS,
   MENTORING_MONTHLY_PRICE,
-  MENTORING_STRIPE_CARD_LINK,
   MENTORING_TOTAL_PRICE,
+  startMentoringCheckout,
 } from './mentoringConfig';
 
 const SCROLL_THRESHOLD = 500;
@@ -43,6 +43,7 @@ const StickyBuyCta = () => {
         currency: 'BRL',
       });
     }
+    void startMentoringCheckout();
   };
 
   return (
@@ -65,23 +66,19 @@ const StickyBuyCta = () => {
               {MENTORING_INSTALLMENTS}x R$ {MENTORING_MONTHLY_PRICE}
             </p>
           </div>
-          <a
-            href={MENTORING_STRIPE_CARD_LINK}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            type="button"
             onClick={handleClick}
             className="inline-flex items-center gap-1.5 rounded-lg bg-gradient-to-r from-amber-500 to-amber-600 px-4 py-2.5 text-xs font-bold text-black shadow-lg shadow-amber-500/20 active:scale-[0.98]"
           >
             <ShoppingCart className="h-3.5 w-3.5" />
             Compre aqui
-          </a>
+          </button>
         </div>
       </div>
 
-      <a
-        href={MENTORING_STRIPE_CARD_LINK}
-        target="_blank"
-        rel="noopener noreferrer"
+      <button
+        type="button"
         onClick={handleClick}
         className="pointer-events-auto hidden items-center gap-3 rounded-full bg-gradient-to-r from-amber-500 to-amber-600 px-5 py-3 text-sm font-bold text-black shadow-2xl shadow-amber-500/30 transition hover:scale-[1.02] hover:shadow-amber-500/50 md:inline-flex"
       >
@@ -89,7 +86,7 @@ const StickyBuyCta = () => {
         <span>
           Compre aqui &middot; {MENTORING_INSTALLMENTS}x R$ {MENTORING_MONTHLY_PRICE}
         </span>
-      </a>
+      </button>
     </div>
   );
 };

--- a/src/components/mentoring/mentoringConfig.ts
+++ b/src/components/mentoring/mentoringConfig.ts
@@ -9,18 +9,25 @@ export const MENTORING_PIX_DISCOUNT_PERCENT = 8;
 export const MENTORING_PIX_PRICE = 1924;
 export const MENTORING_PIX_SAVINGS = MENTORING_TOTAL_PRICE - MENTORING_PIX_PRICE;
 
-// Stripe Payment Links (hosted checkout).
-// IMPORTANT: the success_url and cancel_url for these links are configured in the
-// Stripe Dashboard, not here. Expected values:
-//   success_url: https://dheiver.com.br/#/obrigado?method=cartao  (or ?method=pix)
+// Stripe Payment Link (fallback de checkout hospedado).
+// O checkout primário agora passa por /api/create-checkout, que cria uma Checkout
+// Session com payment_method_options.card.installments.enabled=true — isso
+// garante via código que o parcelamento em 3x aparece pro cliente. O Payment
+// Link abaixo fica como fallback caso o endpoint falhe.
+// Success/cancel URLs do Payment Link são configuradas no Dashboard:
+//   success_url: https://dheiver.com.br/#/obrigado?method=cartao (ou ?method=pix)
 //   cancel_url:  https://dheiver.com.br/
-// If you change these links, re-verify that the Dashboard's success/cancel URLs
-// still point to the correct routes. A mismatch breaks the post-payment flow.
 export const MENTORING_STRIPE_CARD_LINK = 'https://buy.stripe.com/bJe3cxdww6po8F431j93y05';
 // Empty until a Pix-only Stripe Payment Link is created. While empty, the Pix
 // CTAs fall back to a pre-filled WhatsApp message so the user still gets a path
 // to completion (see buildMentoringPixWhatsAppLink below).
 export const MENTORING_STRIPE_PIX_LINK = '';
+
+// Chave publicável do Stripe (segura no frontend — publishable keys são públicas
+// por design). Usada caso se queira montar Stripe Elements; o fluxo atual via
+// create-checkout não precisa dela no cliente.
+export const MENTORING_STRIPE_PUBLISHABLE_KEY =
+  'pk_live_51QyNtCRt1eR0wQGIr9zfeqyE1xxstaCSC4QgTeCKZgsS0cebP2EO927onziOjSObt040KKjzWMFZTrFvC8Iuy6ZT00I7N5hcbV';
 
 export const buildMentoringWhatsAppLink = (message: string) =>
   `https://wa.me/${MENTORING_PHONE}?text=${encodeURIComponent(message)}`;
@@ -29,3 +36,22 @@ export const buildMentoringPixWhatsAppLink = () =>
   buildMentoringWhatsAppLink(
     `Quero pagar a mentoria via Pix (R$ ${MENTORING_PIX_PRICE} - ${MENTORING_PIX_DISCOUNT_PERCENT}% off). Pode me mandar a chave?`
   );
+
+// Cria uma Checkout Session via /api/create-checkout e redireciona o browser.
+// Em caso de falha, cai no Payment Link como fallback pra não quebrar conversão.
+export const startMentoringCheckout = async (email?: string): Promise<void> => {
+  try {
+    const response = await fetch('/api/create-checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (!response.ok) throw new Error(`status ${response.status}`);
+    const data = (await response.json()) as { url?: string };
+    if (!data.url) throw new Error('no url in response');
+    window.location.href = data.url;
+  } catch (err) {
+    console.error('[checkout] create-checkout failed, falling back to Payment Link', err);
+    window.location.href = MENTORING_STRIPE_CARD_LINK;
+  }
+};


### PR DESCRIPTION
## Summary
- Novo endpoint `/api/create-checkout` cria Stripe Checkout Session com `payment_method_options.card.installments.enabled=true` — o plano 3x é oferecido via código, não mais dependendo só do Dashboard do Payment Link.
- Payment Link antigo (`buy.stripe.com/...`) fica como fallback automático se o endpoint falhar.
- CTAs de cartão (MentoringPricing + StickyBuyCta) agora passam pelo endpoint.

## Arquivos
- `api/create-checkout.ts` — novo handler Vercel (BRL, pt-BR, installments on, R$ 2.091 total)
- `src/components/mentoring/mentoringConfig.ts` — helper `startMentoringCheckout()` + publishable key
- `src/components/mentoring/MentoringPricing.tsx` — 2 CTAs chamam o endpoint
- `src/components/mentoring/StickyBuyCta.tsx` — sticky button (mobile + desktop) chama o endpoint
- `.env.example` — documenta STRIPE_SECRET_KEY + publishable key

## Pré-requisitos em produção
- `STRIPE_SECRET_KEY` no Vercel (já existe — o webhook usa).
- **Stripe Dashboard → Settings → Payments → Installments** precisa estar ativado na conta BR. Sem isso, mesmo com o flag `enabled=true`, a opção 3x não renderiza.

## Test plan
- [ ] Typecheck: `npx tsc --noEmit` (verde ✅)
- [ ] Build: `npm run build` (verde ✅)
- [ ] Após deploy: clicar no CTA "PAGAR AGORA" em /mentoria e confirmar que:
  - [ ] Checkout abre em `checkout.stripe.com` (não mais `buy.stripe.com`)
  - [ ] Opção "Parcelar em 3x" aparece na seleção de cartão
  - [ ] Redireciona pra `/#/obrigado?method=cartao&session_id=...` após pagar
- [ ] Webhook `checkout.session.completed` continua gravando em `paid_customers` (sem mudança)

🤖 Generated with [Claude Code](https://claude.com/claude-code)