### PR TITLE
feat(mentoring): switch card flow to 3-month subscription (3x auto-cancel)

### DIFF
--- a/api/stripe-webhook.ts
+++ b/api/stripe-webhook.ts
@@ -182,6 +182,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: `Webhook signature verification failed: ${message}` });
   }
 
+  if (event.type === 'invoice.paid') {
+    const invoice = event.data.object as Stripe.Invoice;
+    const subRef = (invoice as unknown as { subscription?: string | { id: string } }).subscription;
+    const subId = typeof subRef === 'string' ? subRef : subRef?.id;
+    if (subId) {
+      try {
+        const sub = await stripe.subscriptions.retrieve(subId);
+        const maxInvoicesRaw = sub.metadata?.max_invoices;
+        const maxInvoices = maxInvoicesRaw ? parseInt(maxInvoicesRaw, 10) : 0;
+        if (maxInvoices > 0 && !sub.cancel_at_period_end && sub.status !== 'canceled') {
+          const paidInvoices = await stripe.invoices.list({ subscription: subId, status: 'paid', limit: 100 });
+          if (paidInvoices.data.length >= maxInvoices) {
+            await stripe.subscriptions.update(subId, { cancel_at_period_end: true });
+            console.log('[stripe] subscription scheduled to cancel at period end', {
+              subId,
+              paid: paidInvoices.data.length,
+              max: maxInvoices,
+            });
+          }
+        }
+      } catch (err) {
+        console.error('[stripe] invoice.paid auto-cancel failed', {
+          subId,
+          error: err instanceof Error ? err.message : err,
+        });
+        return res.status(500).json({ error: 'invoice.paid handler failed — Stripe should retry.' });
+      }
+    }
+  }
+
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session;
     const email = session.customer_details?.email;

--- a/src/components/mentoring/MentoringPricing.tsx
+++ b/src/components/mentoring/MentoringPricing.tsx
@@ -82,10 +82,10 @@ const MentoringPricing = () => {
               onClick={() => { if (typeof window !== 'undefined' && window.fbq) { window.fbq('track', 'InitiateCheckout', { content_name: 'pricing_card_stripe', value: MENTORING_TOTAL_PRICE, currency: 'BRL' }); } }}
               className="relative bg-[#0D1117] border-2 border-emerald-500/30 rounded-xl p-4 text-left transition-all hover:border-emerald-400/60 hover:bg-[#0F1620] hover:-translate-y-0.5"
             >
-              <span className="absolute -top-2.5 left-3 text-[9px] font-bold tracking-wider bg-emerald-500 text-black px-2 py-0.5 rounded">SEM JUROS</span>
-              <p className="text-[11px] uppercase tracking-wider text-slate-500 mb-1">Cartão de crédito</p>
+              <span className="absolute -top-2.5 left-3 text-[9px] font-bold tracking-wider bg-emerald-500 text-black px-2 py-0.5 rounded">MENSAL</span>
+              <p className="text-[11px] uppercase tracking-wider text-slate-500 mb-1">Cartão — {MENTORING_INSTALLMENTS} parcelas</p>
               <p className="text-xl font-bold text-white leading-tight">{MENTORING_INSTALLMENTS}x de R$ {MENTORING_MONTHLY_PRICE}</p>
-              <p className="text-[11px] text-slate-400 mt-1">Total: R$ {MENTORING_TOTAL_PRICE}</p>
+              <p className="text-[11px] text-slate-400 mt-1">Total: R$ {MENTORING_TOTAL_PRICE} · cobrança mensal</p>
               <p className="text-[10px] text-emerald-400 mt-2 font-semibold">Pagar agora →</p>
             </a>
             <a
@@ -103,7 +103,8 @@ const MentoringPricing = () => {
             </a>
           </div>
 
-          <p className="text-[11px] text-amber-400/70 font-medium mb-6">Inclui acompanhamento individual, projetos guiados, revisão de currículo e preparação para entrevistas.</p>
+          <p className="text-[11px] text-amber-400/70 font-medium mb-2">Inclui acompanhamento individual, projetos guiados, revisão de currículo e preparação para entrevistas.</p>
+          <p className="text-[10px] text-slate-500 mb-6">No cartão, a cobrança é mensal e cancela automaticamente após a 3ª parcela — nunca há 4ª cobrança.</p>
 
           {/* Included */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-left mb-8">

--- a/src/components/mentoring/mentoringConfig.ts
+++ b/src/components/mentoring/mentoringConfig.ts
@@ -10,13 +10,12 @@ export const MENTORING_PIX_PRICE = 1924;
 export const MENTORING_PIX_SAVINGS = MENTORING_TOTAL_PRICE - MENTORING_PIX_PRICE;
 
 // Stripe Payment Links (hosted checkout).
-// IMPORTANT: the success_url and cancel_url for these links are configured in the
-// Stripe Dashboard, not here. Expected values:
-//   success_url: https://dheiver.com.br/#/obrigado?method=cartao  (or ?method=pix)
-//   cancel_url:  https://dheiver.com.br/
-// If you change these links, re-verify that the Dashboard's success/cancel URLs
-// still point to the correct routes. A mismatch breaks the post-payment flow.
-export const MENTORING_STRIPE_CARD_LINK = 'https://buy.stripe.com/bJe3cxdww6po8F431j93y05';
+// Card link runs as a 3-month subscription (R$ 697/mês × 3). Auto-cancels after
+// the 3rd paid invoice via api/stripe-webhook.ts (invoice.paid handler) so the
+// customer is never charged a 4th time. If you swap the link, confirm the new
+// price has metadata {installments:"3"} and the Dashboard's success/cancel URLs
+// still point to https://dheiver.com.br/#/obrigado?method=cartao and /.
+export const MENTORING_STRIPE_CARD_LINK = 'https://buy.stripe.com/aFafZj6448xw3kKeK193y06';
 // Empty until a Pix-only Stripe Payment Link is created. While empty, the Pix
 // CTAs fall back to a pre-filled WhatsApp message so the user still gets a path
 // to completion (see buildMentoringPixWhatsAppLink below).


### PR DESCRIPTION
## Summary
- Card Payment Link (`MENTORING_STRIPE_CARD_LINK`) swapped from one-time R$ 2.091 to a recurring R$ 697/mês price on the same product — same total, same 3 parcelas, but now driven by a subscription.
- Webhook grows an `invoice.paid` handler that counts paid invoices and sets `cancel_at_period_end=true` once `metadata.max_invoices` (=3) is reached. The 4th charge never happens.
- Pricing copy adjusted: CTA badge now reads **MENSAL** instead of **SEM JUROS**, with a fine-print note that the cobrança cancels automatically after the 3ª parcela. Pix path untouched.

## Why this instead of card installments
Stripe Brazil does **not** expose API-level installments (`payment_method_options.card.installments`) — only MX, JP and Mastercard. That's why PR #6 was reverted by #7. A 3-month subscription gives the user the exact same "3 pagamentos de R$ 697" perceived experience, works on any BR card, and is enforceable server-side (no reliance on the bank to split).

## Stripe state (live)
- New recurring price: `price_1TOSRSRt1eR0wQGIcP1A20Y3` · R$ 697/mês · metadata `{installments:"3", max_invoices:"3"}`
- New subscription Payment Link: `plink_1TOSToRt1eR0wQGINJxRPet5` → `https://buy.stripe.com/aFafZj6448xw3kKeK193y06`
- Old one-time link `plink_1TNZwSRt1eR0wQGIEOh81beT` set to `active=false`
- Webhook `we_1TNfxsRt1eR0wQGIV5vtVGtK` now subscribes to `invoice.paid` and `customer.subscription.deleted` in addition to existing events

## Test plan
- [ ] `npx tsc --noEmit` passes (ran locally, exit 0)
- [ ] Load mentoring page in prod, confirm "Compre aqui" CTA opens the new Payment Link URL
- [ ] Run a test purchase in Dashboard (or small real charge) and confirm:
  - [ ] First `invoice.paid` fires → webhook logs, no cancel yet (count=1)
  - [ ] On count=3, webhook sets `cancel_at_period_end=true`
  - [ ] Supabase `paid_customers` row created on `checkout.session.completed` (amount_total = R$ 697, first invoice)
  - [ ] Welcome email from Resend lands once (idempotency key = session.id)
- [ ] Confirm Dashboard success_url still points to `dheiver.com.br/#/obrigado?method=cartao`

🤖 Generated with [Claude Code](https://claude.com/claude-code)