### PR TITLE
feat(mentoring): add 60s VSL section + fix members badge overlap

### DIFF
--- a/src/components/mentoring/MentoringVideoPitch.tsx
+++ b/src/components/mentoring/MentoringVideoPitch.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
+import { ArrowRight, CheckCircle2, Play } from 'lucide-react';
+import { buildMentoringWhatsAppLink } from './mentoringConfig';
+
+const VIDEO_ID = 'aSqsoPaP2jQ';
+const VIDEO_TITLE = 'Apresentação da mentoria em Engenharia de IA';
+
+const talkingPoints = [
+  'Por que estudar sozinho não te leva à primeira vaga em IA',
+  'O plano de 90 dias que substitui o caos de tutoriais por rotina',
+  'Como o portfólio é construído com narrativa de contratação',
+];
+
+const MentoringVideoPitch = () => {
+  const [playing, setPlaying] = useState(false);
+  const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.2 });
+
+  const handlePlay = () => {
+    setPlaying(true);
+    if (typeof window !== 'undefined' && window.fbq) {
+      window.fbq('trackCustom', 'VideoPitchPlay', { content_name: 'mentoring_video_pitch' });
+    }
+  };
+
+  return (
+    <div className="relative w-full bg-[#07090F] py-16 md:py-24 overflow-hidden">
+      {/* Ambient background glow */}
+      <div className="pointer-events-none absolute top-1/3 left-1/2 -translate-x-1/2 w-[520px] h-[520px] rounded-full bg-amber-500/[0.06] blur-[120px]" />
+
+      <div ref={ref} className="relative z-10 max-w-6xl mx-auto px-5 md:px-8">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="text-center mb-10 md:mb-14"
+        >
+          <span className="inline-block text-amber-400 text-xs font-bold tracking-[0.2em] mb-3">
+            APRESENTAÇÃO EM 1 MINUTO
+          </span>
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white tracking-tight">
+            Veja como a mentoria funciona{' '}
+            <span className="bg-gradient-to-r from-amber-400 via-amber-500 to-orange-500 bg-clip-text text-transparent">
+              em 60 segundos
+            </span>
+          </h2>
+          <p className="mt-3 text-sm md:text-base text-slate-400 max-w-2xl mx-auto leading-relaxed">
+            Em pouco mais de um minuto você entende o método, o ritmo das sessões e o que sai do outro lado.
+          </p>
+        </motion.div>
+
+        <div className="grid md:grid-cols-[auto_1fr] gap-10 md:gap-14 items-center justify-items-center md:justify-items-start">
+          {/* Phone-frame video */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={inView ? { opacity: 1, scale: 1 } : {}}
+            transition={{ duration: 0.7, delay: 0.15, ease: [0.22, 1, 0.36, 1] }}
+            className="relative"
+          >
+            {/* Glow ring */}
+            <div className="absolute -inset-6 bg-gradient-to-br from-amber-500/20 via-amber-500/5 to-transparent rounded-[3rem] blur-2xl" />
+
+            {/* Phone frame (9:16) */}
+            <div className="relative w-[260px] sm:w-[280px] md:w-[300px] aspect-[9/16] rounded-[2rem] bg-[#0B0F18] ring-1 ring-slate-800/80 shadow-2xl shadow-black/60 overflow-hidden">
+              {/* Notch */}
+              <div className="absolute top-0 left-1/2 -translate-x-1/2 w-24 h-5 bg-black rounded-b-2xl z-20" />
+
+              {playing ? (
+                <iframe
+                  src={`https://www.youtube.com/embed/${VIDEO_ID}?autoplay=1&rel=0&modestbranding=1&playsinline=1`}
+                  title={VIDEO_TITLE}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
+                  className="absolute inset-0 w-full h-full border-0"
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={handlePlay}
+                  aria-label={`Reproduzir: ${VIDEO_TITLE}`}
+                  className="group relative block w-full h-full text-left"
+                >
+                  <img
+                    src={`https://i.ytimg.com/vi/${VIDEO_ID}/oar2.jpg`}
+                    onError={(e) => {
+                      const img = e.currentTarget as HTMLImageElement;
+                      if (!img.dataset.fallback) {
+                        img.dataset.fallback = '1';
+                        img.src = `https://i.ytimg.com/vi/${VIDEO_ID}/hqdefault.jpg`;
+                      }
+                    }}
+                    alt={`Capa do vídeo: ${VIDEO_TITLE}`}
+                    loading="lazy"
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-transparent to-black/70" />
+
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="flex items-center justify-center w-16 h-16 rounded-full bg-amber-500 text-black shadow-xl shadow-amber-500/40 transition-transform duration-300 group-hover:scale-110">
+                      <Play className="w-7 h-7 fill-current ml-1" />
+                    </span>
+                  </div>
+
+                  <div className="absolute bottom-4 left-4 right-4">
+                    <p className="text-[10px] font-bold tracking-[0.18em] text-amber-300 uppercase">
+                      ▶ 0:60 · Dr. Dheiver
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-white leading-tight">
+                      Como você entra na sua primeira vaga de IA
+                    </p>
+                  </div>
+                </button>
+              )}
+            </div>
+          </motion.div>
+
+          {/* Talking points + CTA */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={inView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.7, delay: 0.3 }}
+            className="w-full max-w-md text-center md:text-left"
+          >
+            <p className="text-xs font-bold tracking-[0.2em] text-amber-400 mb-4">
+              O QUE VOCÊ VAI ENTENDER
+            </p>
+            <ul className="space-y-3.5 mb-6 md:mb-8">
+              {talkingPoints.map((item) => (
+                <li key={item} className="flex items-start gap-3 text-sm md:text-base text-slate-300 leading-relaxed">
+                  <CheckCircle2 className="w-5 h-5 mt-0.5 text-amber-400 flex-shrink-0" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            <a
+              href={buildMentoringWhatsAppLink(
+                'Acabei de assistir a apresentação da mentoria e quero conversar com o Dheiver.'
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => {
+                if (typeof window !== 'undefined' && window.fbq) {
+                  window.fbq('track', 'Lead', { content_name: 'video_pitch_whatsapp_cta' });
+                }
+              }}
+              className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-400 hover:to-amber-500 text-black font-bold text-sm px-6 md:px-8 py-3.5 md:py-4 rounded-xl transition-all duration-300 shadow-lg shadow-amber-500/25"
+            >
+              Quero conversar com o Dheiver
+              <ArrowRight className="w-4 h-4" />
+            </a>
+            <p className="mt-3 text-xs text-slate-500">
+              Resposta em até 24h · Vagas limitadas para esta turma
+            </p>
+          </motion.div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MentoringVideoPitch;

--- a/src/pages/Mentoring.tsx
+++ b/src/pages/Mentoring.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LogIn } from 'lucide-react';
 import MentoringHero from '@/components/mentoring/MentoringHero';
+import MentoringVideoPitch from '@/components/mentoring/MentoringVideoPitch';
 import MentoringPain from '@/components/mentoring/MentoringPain';
 import MentoringFuture from '@/components/mentoring/MentoringFuture';
 import MentoringAuthority from '@/components/mentoring/MentoringAuthority';
@@ -17,10 +18,47 @@ import MentoringCta from '@/components/mentoring/MentoringCta';
 import StickyBuyCta from '@/components/mentoring/StickyBuyCta';
 
 const Mentoring = () => {
+  // Auto-hide top-right Members badge on scroll-down so it stops covering
+  // section content on mobile (e.g. pricing card title). Re-shows on scroll-up
+  // and is always visible at the very top.
+  const [navHidden, setNavHidden] = useState(false);
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+    let ticking = false;
+
+    const handle = () => {
+      const y = window.scrollY;
+      if (y < 120) {
+        setNavHidden(false);
+      } else if (y > lastY + 6) {
+        setNavHidden(true);
+      } else if (y < lastY - 6) {
+        setNavHidden(false);
+      }
+      lastY = y;
+      ticking = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(handle);
+        ticking = true;
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
     <div className="min-h-screen bg-[#07090F] pb-20 md:pb-0">
-      {/* Top-right Area de Membros access — visible on all breakpoints now */}
-      <div className="fixed right-3 top-3 z-50 md:right-5 md:top-5">
+      {/* Top-right Area de Membros access — auto-hides on scroll-down to avoid covering content */}
+      <div
+        className={`fixed right-3 top-3 z-50 md:right-5 md:top-5 transition-all duration-300 ease-out ${
+          navHidden ? 'pointer-events-none -translate-y-4 opacity-0' : 'translate-y-0 opacity-100'
+        }`}
+      >
         <Link
           to="/area-mentorando/login"
           aria-label="Entrar na area de membros"
@@ -37,7 +75,12 @@ const Mentoring = () => {
         <MentoringHero />
       </section>
 
-      {/* 2. DOR — Agita o problema */}
+      {/* 2. VSL — Vídeo de apresentação curto (60s) logo após o gancho */}
+      <section id="mentoring-video-pitch" className="scroll-mt-24">
+        <MentoringVideoPitch />
+      </section>
+
+      {/* 3. DOR — Agita o problema */}
       <section id="mentoring-pain" className="scroll-mt-24">
         <MentoringPain />
       </section>


### PR DESCRIPTION
## Summary
- **VSL section** logo após o hero — vídeo curto (9:16 / YouTube Shorts) em phone-frame com click-to-play (iframe lazy) + 3 talking points + CTA pro WhatsApp. Posição mais alta = maior conversão.
- **Fix mobile UX**: badge "Membros" no topo direito estava cobrindo o título do card de pricing ("Júnior" ficava escondido). Agora some no scroll-down e reaparece no scroll-up (padrão Apple/Medium), com throttle via `requestAnimationFrame`.

## Test plan
- [x] Verificado em desktop (1366px) — phone-frame + content lado a lado
- [x] Verificado em mobile (375px) — sem overflow horizontal, conteúdo empilha corretamente
- [x] Iframe carrega só após click no poster (sem custo de performance no load inicial)
- [x] Tracking fbq: `VideoPitchPlay` (custom) ao tocar e `Lead` no CTA
- [x] Badge auto-hide testado: opacity 0 ao rolar pra baixo, opacity 1 ao rolar pra cima ou no topo (y < 120px)
- [ ] Validar autoplay/CORS do embed do YouTube Shorts em produção
- [ ] QA visual em iOS Safari (notch interaction com badge fixo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)